### PR TITLE
v8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typedly/descriptor",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typedly/descriptor",
-      "version": "7.0.0",
+      "version": "8.0.0",
       "funding": [
         {
           "type": "stripe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typedly/descriptor",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "author": "wwwdev.io <dev@wwwdev.io>",
   "description": "A TypeScript type definitions package for property descriptor.",
   "license": "MIT",

--- a/src/lib/interface/property-descriptor-chain.interface.ts
+++ b/src/lib/interface/property-descriptor-chain.interface.ts
@@ -8,7 +8,7 @@ import { ThisAccessorPropertyDescriptor } from '../type';
  * @template {keyof O} [K=keyof O] The type of the property name in the object.
  * @template {K extends keyof O ? O[K] : any} [V=K extends keyof O ? O[K] : any] The type of the value accessed by the property.
  * @template {boolean} [A=boolean] The type of active property.
- * @template {boolean} [ED=boolean] The type of enabled property.
+ * @template {boolean} [N=boolean] The type of enabled property.
  * @template {boolean} [C=boolean] The type of configurable property.
  * @template {boolean} [E=boolean] The type of enumerable property.
  * @template {ThisAccessorPropertyDescriptor<V, O, C, E>} [D=ThisAccessorPropertyDescriptor<V, O, C, E>] 
@@ -23,7 +23,7 @@ export interface PropertyDescriptorChain<
   // Active.
   A extends boolean = boolean,
   // Enabled.
-  ED extends boolean = boolean,
+  N extends boolean = boolean,
   // Configurable.
   C extends boolean = boolean,
   // Enumerable.
@@ -48,9 +48,9 @@ export interface PropertyDescriptorChain<
   /**
    * @description Whether the chain is enabled.
    * @readonly
-   * @type {ED}
+   * @type {N}
    */
-  get enabled(): ED;
+  get enabled(): N;
 
   /**
    * @description The last index of descriptors in the chain.

--- a/src/lib/interface/property-descriptors.interface.ts
+++ b/src/lib/interface/property-descriptors.interface.ts
@@ -10,11 +10,11 @@ import { ThisAccessorPropertyDescriptor } from '../type';
  * @template {keyof O} [K=keyof O] The type of the property key.
  * @template {K extends keyof O ? O[K] : any} [V=K extends keyof O ? O[K] : any] The type of the property value.
  * @template {boolean} [A=boolean] The type of active property.
- * @template {boolean} [ED=boolean] The type of enabled property.
+ * @template {boolean} [N=boolean] The type of enabled property.
  * @template {boolean} [C=boolean] The type of configurable property.
  * @template {boolean} [E=boolean] The type of enumerable property.
  * @template {ThisAccessorPropertyDescriptor<V, O, C, E>} [D=ThisAccessorPropertyDescriptor<V, O, C, E>] 
- * @template {PropertyDescriptorChain<O, K, V, A, ED, C, E, D>} [DC=PropertyDescriptorChain<O, K, V, A, ED, C, E, D>] 
+ * @template {PropertyDescriptorChain<O, K, V, A, N, C, E, D>} [DC=PropertyDescriptorChain<O, K, V, A, N, C, E, D>] 
  */
 export interface PropertyDescriptors<
   // Object.
@@ -26,7 +26,7 @@ export interface PropertyDescriptors<
   // Active.
   A extends boolean = boolean,
   // Enabled.
-  ED extends boolean = boolean,
+  N extends boolean = boolean,
   // Configurable.
   C extends boolean = boolean,
   // Enumerable.
@@ -34,7 +34,7 @@ export interface PropertyDescriptors<
   // Descriptor.
   D extends ThisAccessorPropertyDescriptor<V, O, C, E> = ThisAccessorPropertyDescriptor<V, O, C, E>,
   // Descriptor Chain.
-  DC extends PropertyDescriptorChain<O, K, V, A, ED, C, E, D> = PropertyDescriptorChain<O, K, V, A, ED, C, E, D>,
+  DC extends PropertyDescriptorChain<O, K, V, A, N, C, E, D> = PropertyDescriptorChain<O, K, V, A, N, C, E, D>,
 > {
   /**
    * @description Adds a new property descriptor to the chain.

--- a/src/lib/interface/wrapped-property-descriptor.interface.ts
+++ b/src/lib/interface/wrapped-property-descriptor.interface.ts
@@ -9,9 +9,10 @@ import { ThisAccessorPropertyDescriptor } from '../type';
  * @template {keyof O} [K=keyof O] The key type constrained by the object `O`.
  * @template {K extends keyof O ? O[K] : any} [V=K extends keyof O ? O[K] : any] The type of the value accessed by the property, which is either the type of the property in the object or `any` if the key does not exist.
  * @template {boolean} [A=boolean] The type of active property, which can be a boolean or an object with `onGet` and `onSet` properties.
- * @template {boolean} [ED=boolean] The type of enabled property.
+ * @template {boolean} [N=boolean] The type of enabled property.
  * @template {boolean} [C=boolean] The type of configurable property.
  * @template {boolean} [E=boolean] The type of enumerable property.
+ * @template {WrappedPropertyDescriptor<O, K, V, A, N, C, E, D> | PropertyDescriptor} [D=PropertyDescriptor] 
  * @extends {Omit<ThisAccessorPropertyDescriptor<V, O, C, E>, 'set' | 'get'>}
  */
 export interface WrappedPropertyDescriptor<
@@ -24,23 +25,25 @@ export interface WrappedPropertyDescriptor<
   // Active.
   A extends boolean = boolean,
   // Enabled.
-  ED extends boolean = boolean,
+  N extends boolean = boolean,
   // Configurable.
   C extends boolean = boolean,
   // Enumerable.
   E extends boolean = boolean,
+  // Descriptor as previous or current in the `set` and `get`.
+  D extends WrappedPropertyDescriptor<O, K, V, A, N, C, E, D> | PropertyDescriptor = PropertyDescriptor
 > extends Omit<ThisAccessorPropertyDescriptor<V, O, C, E>, 'set' | 'get'> {
   /**
    * @description The `set` to wrap the original `set()` method for accessing the `descriptor`.
-   * @type {?(this: O, value: V, descriptor?: WrappedPropertyDescriptor<O, K, V, A, ED, C, E>) => void}
+   * @type {?(this: O, value: V, descriptor?: D) => void}
    */
-  set?: (this: O, value: V, descriptor?: WrappedPropertyDescriptor<O, K, V, A, ED, C, E>) => void;
+  set?: (this: O, value: V, descriptor?: D) => void;
   
   /**
    * @description The `get` to wrap the original `get()` method for accessing the `descriptor`.
-   * @type {?(this: O, descriptor?: WrappedPropertyDescriptor<O, K, V, A, ED, C, E>) => V}
+   * @type {?(this: O, descriptor?: D) => V}
    */
-  get?: (this: O, descriptor?: WrappedPropertyDescriptor<O, K, V, A, ED, C, E>) => V;
+  get?: (this: O, descriptor?: D) => V;
 
   /**
    * @description Whether the property descriptor `onGet` and `onSet` callbacks are active.
@@ -52,15 +55,21 @@ export interface WrappedPropertyDescriptor<
    * @description Whether the property is enabled.
    * If `true`, the property stores the value in the private key.
    * If `false`, the property does not store the value in the private key.
-   * @type {?ED}
+   * @type {?N}
    */
-  enabled?: ED;
+  enabled?: N;
+
+  /**
+   * @description The index of `number` type for chaining.
+   * @type {?number}
+   */
+  index?: number;
 
   /**
    * @description The previous descriptor of the property for unwrapping.
-   * @type {?(WrappedPropertyDescriptor<O, K, V, A, ED, C, E> | PropertyDescriptor)}
+   * @type {?|D}
    */
-  previousDescriptor?: WrappedPropertyDescriptor<O, K, V, A, ED, C, E> | PropertyDescriptor;
+  previousDescriptor?: D;
 
   /**
    * @description The key used to access the property in the object.


### PR DESCRIPTION
- Add generic type variable `D` in the `WrappedPropertyDescriptor` for descriptor to handle previous and current descriptor in the `set` and `get`. Change the `ED` to `N` . ae078224dbb46ee9217a0c6034f6ed4ab832cedf
- Change the `ED` to `N` in `PropertyDescriptors` and `PropertyDescriptorChain`. a10ebe9093972a9435cf49cdb0d1045eb7e1250a